### PR TITLE
ORG-5: Count occurences and print top ten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A Go CLI tool that parses Apple Reminders exported as ICS files, maps recurring 
 
 ```bash
 # Run the program (pass path to folder containing .ics files)
-go run main.go ./reminders
+go run . ./reminders
 
 # Build
 go build ./

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const DAYS_LIMIT = 20
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: organizing-reminders <folder>")
@@ -33,7 +35,7 @@ func main() {
 		}
 	}
 
-	fmt.Printf("Loaded %d reminders\n", len(reminders))
+	fmt.Printf("Loaded %d reminders\n\n", len(reminders))
 
 	// Build day → reminders map over the next year.
 	now := time.Now().UTC()
@@ -64,12 +66,12 @@ func main() {
 		return stats[i].day < stats[j].day
 	})
 
-	// Print top 10.
-	fmt.Println("\nTop 10 busiest days:")
-	limit := 20
-	if len(stats) < limit {
+	// Print top x busiest days.
+	limit := DAYS_LIMIT
+	if len(stats) < DAYS_LIMIT {
 		limit = len(stats)
 	}
+	fmt.Printf("Top %d busiest days:\n", limit)
 	for _, s := range stats[:limit] {
 		fmt.Printf("  %s — %d reminders\n", s.day, s.count)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"time"
 )
 
 func main() {
@@ -26,12 +28,49 @@ func main() {
 			fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", path, err)
 			continue
 		}
-
 		if rem.Status != "COMPLETED" {
-			fmt.Printf("Reminder: %s\n", rem)
 			reminders = append(reminders, rem)
 		}
 	}
 
 	fmt.Printf("Loaded %d reminders\n", len(reminders))
+
+	// Build day → reminders map over the next year.
+	now := time.Now().UTC()
+	windowStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.AddDate(1, 0, 0)
+
+	dayMap := make(map[string][]*Reminder)
+	for _, rem := range reminders {
+		for _, occ := range rem.Occurrences(windowStart, windowEnd) {
+			key := occ.Format(time.DateOnly)
+			dayMap[key] = append(dayMap[key], rem)
+		}
+	}
+
+	// Sort days by descending occurrence count.
+	type dayStat struct {
+		day   string
+		count int
+	}
+	stats := make([]dayStat, 0, len(dayMap))
+	for day, rems := range dayMap {
+		stats = append(stats, dayStat{day, len(rems)})
+	}
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].count != stats[j].count {
+			return stats[i].count > stats[j].count
+		}
+		return stats[i].day < stats[j].day
+	})
+
+	// Print top 10.
+	fmt.Println("\nTop 10 busiest days:")
+	limit := 20
+	if len(stats) < limit {
+		limit = len(stats)
+	}
+	for _, s := range stats[:limit] {
+		fmt.Printf("  %s — %d reminders\n", s.day, s.count)
+	}
 }

--- a/reminder.go
+++ b/reminder.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // RRule holds parsed recurrence rule fields from an RRULE line.
@@ -23,6 +24,26 @@ type Reminder struct {
 	Summary string
 	DtStart string
 	RRule   *RRule
+}
+
+// Occurrences returns all dates this reminder falls on in [windowStart, windowEnd].
+func (r *Reminder) Occurrences(windowStart time.Time, windowEnd time.Time) []time.Time {
+	dtStart, err := parseDtStart(r.DtStart)
+	if err != nil {
+		return nil
+	}
+
+	// Normalize to midnight so comparisons are day-based.
+	dtStart = time.Date(dtStart.Year(), dtStart.Month(), dtStart.Day(), 0, 0, 0, 0, time.UTC)
+
+	if r.RRule == nil {
+		if !dtStart.Before(windowStart) && !dtStart.After(windowEnd) {
+			return []time.Time{dtStart}
+		}
+		return nil
+	}
+
+	return findOccurrences(dtStart, r.RRule, windowStart, windowEnd)
 }
 
 func (r *Reminder) String() string {
@@ -109,4 +130,14 @@ func parseRRule(value string) (*RRule, error) {
 		return nil, fmt.Errorf("RRULE missing FREQ")
 	}
 	return r, nil
+}
+
+// parseDtStart parses an ICS DTSTART value into a time.Time (date-only or datetime).
+func parseDtStart(s string) (time.Time, error) {
+	for _, layout := range []string{"20060102T150405Z", "20060102T150405", "20060102"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse DTSTART %q", s)
 }

--- a/reminder.go
+++ b/reminder.go
@@ -9,6 +9,33 @@ import (
 	"time"
 )
 
+type ICSKey string
+
+const (
+	ICSKeyUID     ICSKey = "UID"
+	ICSKeySummary ICSKey = "SUMMARY"
+	ICSKeyStatus  ICSKey = "STATUS"
+	ICSKeyDtStart ICSKey = "DTSTART"
+	ICSKeyRRule   ICSKey = "RRULE"
+)
+
+type RRuleKey string
+
+const (
+	RRuleKeyFreq     RRuleKey = "FREQ"
+	RRuleKeyByDay    RRuleKey = "BYDAY"
+	RRuleKeyInterval RRuleKey = "INTERVAL"
+	RRuleKeyBySetPos RRuleKey = "BYSETPOS"
+)
+
+type DTStartLayout string
+
+const (
+	DTStartLayoutDateTimeUTC DTStartLayout = "20060102T150405Z"
+	DTStartLayoutDateTime    DTStartLayout = "20060102T150405"
+	DTStartLayoutDate        DTStartLayout = "20060102"
+)
+
 // RRule holds parsed recurrence rule fields from an RRULE line.
 type RRule struct {
 	Freq     string   // YEARLY, MONTHLY, WEEKLY, DAILY
@@ -71,16 +98,16 @@ func parseICS(path string) (*Reminder, error) {
 		}
 		// DTSTART may have parameters: "DTSTART;VALUE=DATE:20260720"
 		baseKey := strings.SplitN(key, ";", 2)[0]
-		switch baseKey {
-		case "UID":
+		switch ICSKey(baseKey) {
+		case ICSKeyUID:
 			rem.UID = value
-		case "SUMMARY":
+		case ICSKeySummary:
 			rem.Summary = value
-		case "STATUS":
+		case ICSKeyStatus:
 			rem.Status = value
-		case "DTSTART":
+		case ICSKeyDtStart:
 			rem.DtStart = value
-		case "RRULE":
+		case ICSKeyRRule:
 			rem.RRule, err = parseRRule(value)
 			if err != nil {
 				return nil, fmt.Errorf("%s: %w", path, err)
@@ -107,18 +134,18 @@ func parseRRule(value string) (*RRule, error) {
 			continue
 		}
 		key, val := kv[0], kv[1]
-		switch key {
-		case "FREQ":
+		switch RRuleKey(key) {
+		case RRuleKeyFreq:
 			r.Freq = val
-		case "BYDAY":
+		case RRuleKeyByDay:
 			r.ByDay = strings.Split(val, ",")
-		case "INTERVAL":
+		case RRuleKeyInterval:
 			n, err := strconv.Atoi(val)
 			if err != nil {
 				return nil, fmt.Errorf("invalid INTERVAL %q: %w", val, err)
 			}
 			r.Interval = n
-		case "BYSETPOS":
+		case RRuleKeyBySetPos:
 			n, err := strconv.Atoi(val)
 			if err != nil {
 				return nil, fmt.Errorf("invalid BYSETPOS %q: %w", val, err)
@@ -134,7 +161,7 @@ func parseRRule(value string) (*RRule, error) {
 
 // parseDtStart parses an ICS DTSTART value into a time.Time (date-only or datetime).
 func parseDtStart(s string) (time.Time, error) {
-	for _, layout := range []string{"20060102T150405Z", "20060102T150405", "20060102"} {
+	for _, layout := range []string{string(DTStartLayoutDateTimeUTC), string(DTStartLayoutDateTime), string(DTStartLayoutDate)} {
 		if t, err := time.Parse(layout, s); err == nil {
 			return t, nil
 		}

--- a/time.go
+++ b/time.go
@@ -5,6 +5,15 @@ import (
 	"time"
 )
 
+type RRuleFrequency string
+
+const (
+	FREQ_DAILY   RRuleFrequency = "DAILY"
+	FREQ_WEEKLY  RRuleFrequency = "WEEKLY"
+	FREQ_MONTHLY RRuleFrequency = "MONTHLY"
+	FREQ_YEARLY  RRuleFrequency = "YEARLY"
+)
+
 var weekdays = map[string]time.Weekday{
 	"SU": time.Sunday,
 	"MO": time.Monday,
@@ -41,15 +50,15 @@ func nthWeekdayInMonth(year int, month time.Month, byDay []string, bySetPos int)
 func findOccurrences(dtStart time.Time, rr *RRule, windowStart time.Time, windowEnd time.Time) []time.Time {
 	var results []time.Time
 
-	switch rr.Freq {
-	case "DAILY":
+	switch RRuleFrequency(rr.Freq) {
+	case FREQ_DAILY:
 		for t := dtStart; !t.After(windowEnd); t = t.AddDate(0, 0, rr.Interval) {
 			if !t.Before(windowStart) {
 				results = append(results, t)
 			}
 		}
 
-	case "WEEKLY":
+	case FREQ_WEEKLY:
 		if len(rr.ByDay) == 0 {
 			for t := dtStart; !t.After(windowEnd); t = t.AddDate(0, 0, 7*rr.Interval) {
 				if !t.Before(windowStart) {
@@ -74,7 +83,7 @@ func findOccurrences(dtStart time.Time, rr *RRule, windowStart time.Time, window
 			}
 		}
 
-	case "MONTHLY":
+	case FREQ_MONTHLY:
 		year, month, _ := dtStart.Date()
 		if len(rr.ByDay) > 0 && rr.BySetPos != 0 {
 			for m := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC); !m.After(windowEnd); m = m.AddDate(0, rr.Interval, 0) {
@@ -92,7 +101,7 @@ func findOccurrences(dtStart time.Time, rr *RRule, windowStart time.Time, window
 			}
 		}
 
-	case "YEARLY":
+	case FREQ_YEARLY:
 		for t := dtStart; !t.After(windowEnd); t = t.AddDate(rr.Interval, 0, 0) {
 			if !t.Before(windowStart) {
 				results = append(results, t)

--- a/time.go
+++ b/time.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+var weekdays = map[string]time.Weekday{
+	"SU": time.Sunday,
+	"MO": time.Monday,
+	"TU": time.Tuesday,
+	"WE": time.Wednesday,
+	"TH": time.Thursday,
+	"FR": time.Friday,
+	"SA": time.Saturday,
+}
+
+// nthWeekdayInMonth returns the date of the bySetPos-th occurrence of any weekday
+// in byDay within the given month (1-based positive or negative index).
+func nthWeekdayInMonth(year int, month time.Month, byDay []string, bySetPos int) time.Time {
+	first := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	last := first.AddDate(0, 1, -1)
+	var occurrences []time.Time
+	for d := first; !d.After(last); d = d.AddDate(0, 0, 1) {
+		for _, day := range byDay {
+			if wd, ok := weekdays[day]; ok && d.Weekday() == wd {
+				occurrences = append(occurrences, d)
+				break
+			}
+		}
+	}
+	if bySetPos > 0 && bySetPos <= len(occurrences) {
+		return occurrences[bySetPos-1]
+	}
+	if bySetPos < 0 && -bySetPos <= len(occurrences) {
+		return occurrences[len(occurrences)+bySetPos]
+	}
+	return time.Time{}
+}
+
+func findOccurrences(dtStart time.Time, rr *RRule, windowStart time.Time, windowEnd time.Time) []time.Time {
+	var results []time.Time
+
+	switch rr.Freq {
+	case "DAILY":
+		for t := dtStart; !t.After(windowEnd); t = t.AddDate(0, 0, rr.Interval) {
+			if !t.Before(windowStart) {
+				results = append(results, t)
+			}
+		}
+
+	case "WEEKLY":
+		if len(rr.ByDay) == 0 {
+			for t := dtStart; !t.After(windowEnd); t = t.AddDate(0, 0, 7*rr.Interval) {
+				if !t.Before(windowStart) {
+					results = append(results, t)
+				}
+			}
+		} else {
+			// Walk week-by-week (Sunday-anchored) starting from dtStart's week.
+			weekSun := dtStart.AddDate(0, 0, -int(dtStart.Weekday()))
+			for ; !weekSun.After(windowEnd); weekSun = weekSun.AddDate(0, 0, 7*rr.Interval) {
+				for _, day := range rr.ByDay {
+					wd, ok := weekdays[day]
+					if !ok {
+						fmt.Printf("Failed to find weekday %v\n", day)
+						continue
+					}
+					t := weekSun.AddDate(0, 0, int(wd))
+					if !t.Before(dtStart) && !t.Before(windowStart) && !t.After(windowEnd) {
+						results = append(results, t)
+					}
+				}
+			}
+		}
+
+	case "MONTHLY":
+		year, month, _ := dtStart.Date()
+		if len(rr.ByDay) > 0 && rr.BySetPos != 0 {
+			for m := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC); !m.After(windowEnd); m = m.AddDate(0, rr.Interval, 0) {
+				t := nthWeekdayInMonth(m.Year(), m.Month(), rr.ByDay, rr.BySetPos)
+				if !t.IsZero() && !t.Before(dtStart) && !t.Before(windowStart) && !t.After(windowEnd) {
+					results = append(results, t)
+				}
+			}
+		} else {
+			_, _, dom := dtStart.Date()
+			for t := time.Date(year, month, dom, 0, 0, 0, 0, time.UTC); !t.After(windowEnd); t = t.AddDate(0, rr.Interval, 0) {
+				if !t.Before(windowStart) {
+					results = append(results, t)
+				}
+			}
+		}
+
+	case "YEARLY":
+		for t := dtStart; !t.After(windowEnd); t = t.AddDate(rr.Interval, 0, 0) {
+			if !t.Before(windowStart) {
+				results = append(results, t)
+			}
+		}
+
+	default:
+		fmt.Printf("Error: Unknown frequency: %v\n", rr.Freq)
+	}
+
+	return results
+}


### PR DESCRIPTION
# Problem

I need to know which days have a lot of reminders. That way I can better organize my events.

Closes #5 

## Solution

- For each reminder, find each occurrence over the next year
- Count how many occurrences on each day
- Sort each day by most occurrences
- Print the top 10 day with most occurrences 

## Steps to test

1. Run `go run . ./reminders`